### PR TITLE
style: standardize the indentation of yaml files to 2 spaces

### DIFF
--- a/tpl/kitex/server/standard/conf_dev_tpl.yaml
+++ b/tpl/kitex/server/standard/conf_dev_tpl.yaml
@@ -3,23 +3,23 @@ update_behavior:
   type: skip
 body: |-
   kitex:
-      service: "{{.RealServiceName}}"
-      address: ":8888"
-      log_level: info
-      log_file_name: "log/kitex.log"
-      log_max_size: 10
-      log_max_age: 3
-      log_max_backups: 50
+    service: "{{.RealServiceName}}"
+    address: ":8888"
+    log_level: info
+    log_file_name: "log/kitex.log"
+    log_max_size: 10
+    log_max_age: 3
+    log_max_backups: 50
 
   registry:
     registry_address:
-        - 127.0.0.1:2379
+      - 127.0.0.1:2379
     username: ""
     password: ""
 
   mysql:
-      dsn: "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
+    dsn: "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
   redis:
-      address: "127.0.0.1:6379"
-      username: ""
-      password: ""
+    address: "127.0.0.1:6379"
+    username: ""
+    password: ""

--- a/tpl/kitex/server/standard/conf_online_tpl.yaml
+++ b/tpl/kitex/server/standard/conf_online_tpl.yaml
@@ -3,23 +3,23 @@ update_behavior:
   type: skip
 body: |-
   kitex:
-      service: "{{.RealServiceName}}"
-      address: ":8888"
-      log_level: info
-      log_file_name: "log/kitex.log"
-      log_max_size: 10
-      log_max_age: 3
-      log_max_backups: 50
+    service: "{{.RealServiceName}}"
+    address: ":8888"
+    log_level: info
+    log_file_name: "log/kitex.log"
+    log_max_size: 10
+    log_max_age: 3
+    log_max_backups: 50
 
   registry:
     registry_address:
-        - 127.0.0.1:2379
+      - 127.0.0.1:2379
     username: ""
     password: ""
 
   mysql:
-      dsn: "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
+    dsn: "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
   redis:
-      address: "127.0.0.1:6379"
-      username: ""
-      password: ""
+    address: "127.0.0.1:6379"
+    username: ""
+    password: ""

--- a/tpl/kitex/server/standard/conf_test_tpl.yaml
+++ b/tpl/kitex/server/standard/conf_test_tpl.yaml
@@ -3,23 +3,23 @@ update_behavior:
   type: skip
 body: |-
   kitex:
-      service: "{{.RealServiceName}}"
-      address: ":8888"
-      log_level: info
-      log_file_name: "log/kitex.log"
-      log_max_size: 10
-      log_max_age: 3
-      log_max_backups: 50
+    service: "{{.RealServiceName}}"
+    address: ":8888"
+    log_level: info
+    log_file_name: "log/kitex.log"
+    log_max_size: 10
+    log_max_age: 3
+    log_max_backups: 50
 
   registry:
     registry_address:
-        - 127.0.0.1:2379
+      - 127.0.0.1:2379
     username: ""
     password: ""
 
   mysql:
-      dsn: "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
+    dsn: "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
   redis:
-      address: "127.0.0.1:6379"
-      username: ""
-      password: ""
+    address: "127.0.0.1:6379"
+    username: ""
+    password: ""

--- a/tpl/kitex/server/standard/kitex_yaml.yaml
+++ b/tpl/kitex/server/standard/kitex_yaml.yaml
@@ -3,5 +3,5 @@ update_behavior:
   type: cover
 body: |-
   kitexinfo:
-     ServiceName: '{{.RealServiceName}}'
-     ToolVersion: '{{.Version}}
+    ServiceName: '{{.RealServiceName}}'
+    ToolVersion: '{{.Version}}


### PR DESCRIPTION
#### What type of PR is this?
style
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: standardize the indentation of yaml files to 2 spaces
zh: 将 yaml 文件的缩进统一为 2个空格

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
