### PR TITLE
Revert "fix: add absolute path for config (#84)"

### DIFF
--- a/tpl/hertz/server/standard/layout.yaml
+++ b/tpl/hertz/server/standard/layout.yaml
@@ -115,14 +115,11 @@ layouts:
       package conf
 
       import (
-        "bytes"
       	"io/ioutil"
       	"os"
-        "os/exec"
       	"path/filepath"
       	"sync"
 
-        "github.com/bytedance/sonic"
       	"github.com/cloudwego/hertz/pkg/common/hlog"
       	"github.com/kr/pretty"
       	"gopkg.in/validator.v2"
@@ -146,6 +143,7 @@ layouts:
       	DSN string `yaml:"dsn"`
       }
 
+
       type Redis struct {
       	Address  string `yaml:"address"`
       	Password string `yaml:"password"`
@@ -164,10 +162,6 @@ layouts:
       	LogMaxBackups int    `yaml:"log_max_backups"`
       	LogMaxAge     int    `yaml:"log_max_age"`
       }
-      
-      type BindMainDir struct {
-        Dir string `json:"Dir"`
-      }
 
       // GetConf gets configuration instance
       func GetConf() *Config {
@@ -176,7 +170,8 @@ layouts:
       }
 
       func initConf() {
-      	confFileRelPath := getConfAbsPath()
+      	prefix := "conf"
+      	confFileRelPath := filepath.Join(prefix, filepath.Join(GetEnv(), "conf.yaml"))
       	content, err := ioutil.ReadFile(confFileRelPath)
       	if err != nil {
       		panic(err)
@@ -197,26 +192,7 @@ layouts:
 
       	pretty.Printf("%+v\n", conf)
       }
-      
-      func getConfAbsPath() string {
-        cmd := exec.Command("go", "list", "-m", "-json")
-      
-        var out bytes.Buffer
-        cmd.Stdout = &out
-        cmd.Stderr = &out
-        if err := cmd.Run(); err != nil {
-          panic(err)
-        }
-      
-        bindDir := &BindMainDir{}
-        if err := sonic.Unmarshal(out.Bytes(), bindDir); err != nil {
-          panic(err)
-        }
 
-        prefix := "conf"
-        return filepath.Join(bindDir.Dir, prefix, filepath.Join(GetEnv(), "conf.yaml"))
-      }
-      
       func GetEnv() string {
       	e := os.Getenv("GO_ENV")
       	if len(e) == 0 {
@@ -246,6 +222,7 @@ layouts:
       		return hlog.LevelInfo
       	}
       }
+
 
   - path: conf/dev/conf.yaml
     delims:
@@ -321,6 +298,7 @@ layouts:
         username: ""
         password: ""
         db: 0
+
 
   - path: biz/dal/init.go
     delims:

--- a/tpl/kitex/server/standard/conf_tpl.yaml
+++ b/tpl/kitex/server/standard/conf_tpl.yaml
@@ -5,14 +5,11 @@ body: |-
   package conf
 
   import (
-    "bytes"
     "io/ioutil"
     "os"
-    "os/exec"
     "path/filepath"
     "sync"
 
-    "github.com/bytedance/sonic"
     "github.com/cloudwego/kitex/pkg/klog"
     "github.com/kr/pretty"
     "gopkg.in/validator.v2"
@@ -35,7 +32,7 @@ body: |-
   type MySQL struct {
     DSN string `yaml:"dsn"`
   }
-  
+
   type Redis struct {
     Address  string `yaml:"address"`
     Username string `yaml:"username"`
@@ -61,10 +58,6 @@ body: |-
   	Username        string   `yaml:"username"`
   	Password        string   `yaml:"password"`
   }
-  
-  type BindMainDir struct {
-    Dir string `json:"Dir"`
-  }
 
   // GetConf gets configuration instance
   func GetConf() *Config {
@@ -73,7 +66,8 @@ body: |-
   }
 
   func initConf() {
-    confFileRelPath := getConfAbsPath()
+    prefix := "conf"
+    confFileRelPath := filepath.Join(prefix, filepath.Join(GetEnv(), "conf.yaml"))
     content, err := ioutil.ReadFile(confFileRelPath)
     if err != nil {
       panic(err)
@@ -91,25 +85,6 @@ body: |-
     conf.Env = GetEnv()
     pretty.Printf("%+v\n", conf)
   }
-  
-  func getConfAbsPath() string {
-    cmd := exec.Command("go", "list", "-m", "-json")
-  
-    var out bytes.Buffer
-    cmd.Stdout = &out
-    cmd.Stderr = &out
-    if err := cmd.Run(); err != nil {
-      panic(err)
-    }
-  
-    bindDir := &BindMainDir{}
-    if err := sonic.Unmarshal(out.Bytes(), bindDir); err != nil {
-      panic(err)
-    }
-
-    prefix := "conf"
-    return filepath.Join(bindDir.Dir, prefix, filepath.Join(GetEnv(), "conf.yaml"))
-  }
 
   func GetEnv() string {
     e := os.Getenv("GO_ENV")
@@ -118,7 +93,7 @@ body: |-
     }
     return e
   }
-  
+
   func LogLevel() klog.Level {
     level := GetConf().Kitex.LogLevel
     switch level {


### PR DESCRIPTION
This reverts commit 97b4535f6fa2d113d59f2e7c09ad80787a2a1171.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Revert "fix: add absolute path for config (#84)"
zh: 恢复配置路径读取逻辑

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #95 
