### PR TITLE
fix(platform): GetAgentClientByServiceId cannot use frugal

### DIFF
--- a/platform/server/shared/consts/consts.go
+++ b/platform/server/shared/consts/consts.go
@@ -48,6 +48,8 @@ const (
 	TempDirGeneratedCode = "generated_code" // generated code temp dir
 )
 
+const ServiceID = "service_id"
+
 var TempDir string
 
 func init() {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: 
zh: 将 GetAgentClient 抽象为 newAgentClient 进行复用, 修复 GetAgentClientByServiceId 没有开启 frugal 编解码的问题

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
