### PR TITLE
fix(model): --tables option doesn't work when --only_model is false

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -85,7 +85,6 @@ func Model(c *config.ModelArgument) error {
 
 	if !c.OnlyModel {
 		g.ApplyBasic(models...)
-		g.ApplyBasic(g.GenerateAllTable()...)
 	}
 
 	g.Execute()


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix `--tables` option doesn't work when `--only_model` is false
zh: 修复当`--only_model`为`false`时--tables选项无法使用

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
