### PR TITLE
fix:change the parameter service to server_name

### DIFF
--- a/cmd/static/client_flags.go
+++ b/cmd/static/client_flags.go
@@ -25,7 +25,8 @@ import (
 func clientFlags() []cli.Flag {
 	globalArgs := config.GetGlobalArgs()
 	return []cli.Flag{
-		&cli.StringFlag{Name: consts.Service, Usage: "Specify the service name.", Destination: &globalArgs.ClientArgument.Service},
+		&cli.StringFlag{Name: consts.Service, Usage: "Specify the server name.(Not recommended)", Destination: &globalArgs.ClientArgument.ServerName},
+		&cli.StringFlag{Name: consts.ServerName, Usage: "Specify the server name.", Destination: &globalArgs.ClientArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServiceType, Usage: "Specify the generate type. (RPC or HTTP)", Value: consts.RPC},
 		&cli.StringFlag{Name: consts.Module, Aliases: []string{"mod"}, Usage: "Specify the Go module name to generate go.mod.", Destination: &globalArgs.ClientArgument.GoMod},
 		&cli.StringFlag{Name: consts.IDLPath, Usage: "Specify the IDL file path. (.thrift or .proto)", Destination: &globalArgs.ClientArgument.IdlPath},

--- a/cmd/static/client_flags.go
+++ b/cmd/static/client_flags.go
@@ -25,7 +25,7 @@ import (
 func clientFlags() []cli.Flag {
 	globalArgs := config.GetGlobalArgs()
 	return []cli.Flag{
-		&cli.StringFlag{Name: consts.Service, Usage: "Specify the server name.(Not recommended)", Destination: &globalArgs.ClientArgument.ServerName},
+		&cli.StringFlag{Name: consts.Service, Usage: "Specify the server name.(Not recommended,Deprecate in v0.2.0)", Destination: &globalArgs.ClientArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServerName, Usage: "Specify the server name.", Destination: &globalArgs.ClientArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServiceType, Usage: "Specify the generate type. (RPC or HTTP)", Value: consts.RPC},
 		&cli.StringFlag{Name: consts.Module, Aliases: []string{"mod"}, Usage: "Specify the Go module name to generate go.mod.", Destination: &globalArgs.ClientArgument.GoMod},

--- a/cmd/static/server_flags.go
+++ b/cmd/static/server_flags.go
@@ -26,6 +26,7 @@ func serverFlags() []cli.Flag {
 	globalArgs := config.GetGlobalArgs()
 	return []cli.Flag{
 		&cli.StringFlag{Name: consts.Service, Usage: "Specify the service name.", Destination: &globalArgs.ServerArgument.Service},
+		&cli.StringFlag{Name: consts.ServerName, Usage: "Specify the server name.", Destination: &globalArgs.ServerArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServiceType, Usage: "Specify the generate type. (RPC or HTTP)", Value: consts.RPC},
 		&cli.StringFlag{Name: consts.Module, Aliases: []string{"mod"}, Usage: "Specify the Go module name to generate go.mod.", Destination: &globalArgs.ServerArgument.GoMod},
 		&cli.StringFlag{Name: consts.IDLPath, Usage: "Specify the IDL file path. (.thrift or .proto)", Destination: &globalArgs.ServerArgument.IdlPath},

--- a/cmd/static/server_flags.go
+++ b/cmd/static/server_flags.go
@@ -25,7 +25,7 @@ import (
 func serverFlags() []cli.Flag {
 	globalArgs := config.GetGlobalArgs()
 	return []cli.Flag{
-		&cli.StringFlag{Name: consts.Service, Usage: "Specify the server name.(Not recommended)", Destination: &globalArgs.ServerArgument.ServerName},
+		&cli.StringFlag{Name: consts.Service, Usage: "Specify the server name.(Not recommended,Deprecate in v0.2.0)", Destination: &globalArgs.ServerArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServerName, Usage: "Specify the server name.", Destination: &globalArgs.ServerArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServiceType, Usage: "Specify the generate type. (RPC or HTTP)", Value: consts.RPC},
 		&cli.StringFlag{Name: consts.Module, Aliases: []string{"mod"}, Usage: "Specify the Go module name to generate go.mod.", Destination: &globalArgs.ServerArgument.GoMod},

--- a/cmd/static/server_flags.go
+++ b/cmd/static/server_flags.go
@@ -25,7 +25,7 @@ import (
 func serverFlags() []cli.Flag {
 	globalArgs := config.GetGlobalArgs()
 	return []cli.Flag{
-		&cli.StringFlag{Name: consts.Service, Usage: "Specify the service name.", Destination: &globalArgs.ServerArgument.Service},
+		&cli.StringFlag{Name: consts.Service, Usage: "Specify the server name.(Not recommended)", Destination: &globalArgs.ServerArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServerName, Usage: "Specify the server name.", Destination: &globalArgs.ServerArgument.ServerName},
 		&cli.StringFlag{Name: consts.ServiceType, Usage: "Specify the generate type. (RPC or HTTP)", Value: consts.RPC},
 		&cli.StringFlag{Name: consts.Module, Aliases: []string{"mod"}, Usage: "Specify the Go module name to generate go.mod.", Destination: &globalArgs.ServerArgument.GoMod},

--- a/config/server.go
+++ b/config/server.go
@@ -40,7 +40,6 @@ type ServerArgument struct {
 }
 
 type CommonParam struct {
-	Service    string // service name
 	ServerName string //server name
 	Type       string // GenerateType: RPC or HTTP
 	GoMod      string // Go Mod name

--- a/config/server.go
+++ b/config/server.go
@@ -40,7 +40,7 @@ type ServerArgument struct {
 }
 
 type CommonParam struct {
-	ServerName string //server name
+	ServerName string // server name
 	Type       string // GenerateType: RPC or HTTP
 	GoMod      string // Go Mod name
 	IdlPath    string

--- a/config/server.go
+++ b/config/server.go
@@ -40,12 +40,13 @@ type ServerArgument struct {
 }
 
 type CommonParam struct {
-	Service  string // service name
-	Type     string // GenerateType: RPC or HTTP
-	GoMod    string // Go Mod name
-	IdlPath  string
-	OutDir   string // output path
-	Registry string
+	Service    string // service name
+	ServerName string //server name
+	Type       string // GenerateType: RPC or HTTP
+	GoMod      string // Go Mod name
+	IdlPath    string
+	OutDir     string // output path
+	Registry   string
 }
 
 func NewServerArgument() *ServerArgument {

--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -41,8 +41,8 @@ func check(ca *config.ClientArgument) error {
 		return errors.New("unsupported registry")
 	}
 
-	if ca.Service == "" {
-		return errors.New("must specify service name when use registry")
+	if ca.Service == "" && ca.ServerName == "" {
+		return errors.New("must specify server name when use registry")
 	}
 
 	// handle cwd and output dir

--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -41,8 +41,8 @@ func check(ca *config.ClientArgument) error {
 		return errors.New("unsupported registry")
 	}
 
-	if ca.Service == "" && ca.ServerName == "" {
-		return errors.New("must specify server name when use registry")
+	if ca.ServerName == "" {
+		return errors.New("must specify server name")
 	}
 
 	// handle cwd and output dir

--- a/pkg/client/hz.go
+++ b/pkg/client/hz.go
@@ -61,7 +61,12 @@ func convertHzArgument(ca *config.ClientArgument, hzArgument *hzConfig.Argument)
 
 	hzArgument.IdlPaths = []string{abPath}
 	hzArgument.Gomod = ca.GoMod
-	hzArgument.ServiceName = ca.Service
+	if ca.Service != "" {
+		hzArgument.ServiceName = ca.Service
+	}
+	if ca.ServerName != "" {
+		hzArgument.ServiceName = ca.ServerName
+	}
 	hzArgument.Includes = ca.SliceParam.ProtoSearchPath
 	hzArgument.Cwd = ca.Cwd
 	hzArgument.Gosrc = ca.GoSrc

--- a/pkg/client/hz.go
+++ b/pkg/client/hz.go
@@ -61,12 +61,7 @@ func convertHzArgument(ca *config.ClientArgument, hzArgument *hzConfig.Argument)
 
 	hzArgument.IdlPaths = []string{abPath}
 	hzArgument.Gomod = ca.GoMod
-	if ca.Service != "" {
-		hzArgument.ServiceName = ca.Service
-	}
-	if ca.ServerName != "" {
-		hzArgument.ServiceName = ca.ServerName
-	}
+	hzArgument.ServiceName = ca.ServerName
 	hzArgument.Includes = ca.SliceParam.ProtoSearchPath
 	hzArgument.Cwd = ca.Cwd
 	hzArgument.Gosrc = ca.GoSrc

--- a/pkg/client/kitex.go
+++ b/pkg/client/kitex.go
@@ -39,6 +39,12 @@ func convertKitexArgs(sa *config.ClientArgument, kitexArgument *kargs.Arguments)
 
 	kitexArgument.ModuleName = sa.GoMod
 	kitexArgument.ServiceName = sa.Service
+	if sa.Service != "" {
+		kitexArgument.ServiceName = sa.Service
+	}
+	if sa.ServerName != "" {
+		kitexArgument.ServiceName = sa.ServerName
+	}
 	kitexArgument.Includes = sa.SliceParam.ProtoSearchPath
 	kitexArgument.Version = kitex.Version
 	kitexArgument.RecordCmd = os.Args

--- a/pkg/client/kitex.go
+++ b/pkg/client/kitex.go
@@ -38,13 +38,7 @@ func convertKitexArgs(sa *config.ClientArgument, kitexArgument *kargs.Arguments)
 	f := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 	kitexArgument.ModuleName = sa.GoMod
-	kitexArgument.ServiceName = sa.Service
-	if sa.Service != "" {
-		kitexArgument.ServiceName = sa.Service
-	}
-	if sa.ServerName != "" {
-		kitexArgument.ServiceName = sa.ServerName
-	}
+	kitexArgument.ServiceName = sa.ServerName
 	kitexArgument.Includes = sa.SliceParam.ProtoSearchPath
 	kitexArgument.Version = kitex.Version
 	kitexArgument.RecordCmd = os.Args

--- a/pkg/common/kx_registry/registry.go
+++ b/pkg/common/kx_registry/registry.go
@@ -41,7 +41,7 @@ func HandleRegistry(ca *config.CommonParam, dir string) {
 		te.Dependencies["github.com/kitex-contrib/registry-etcd"] = "etcd"
 		te.ExtendServer = &generator.APIExtension{
 			ImportPaths:  append(importPath, "github.com/kitex-contrib/registry-etcd", "github.com/cloudwego/kitex/pkg/rpcinfo"),
-			ExtendOption: fmt.Sprintf(etcdServer, ca.Service),
+			ExtendOption: fmt.Sprintf(etcdServer, ca.ServerName),
 		}
 		te.ExtendClient = &generator.APIExtension{
 			ImportPaths:  append(importPath, "github.com/kitex-contrib/registry-etcd"),
@@ -64,18 +64,18 @@ func HandleRegistry(ca *config.CommonParam, dir string) {
 		te.Dependencies["github.com/cloudwego/kitex/pkg/registry"] = "registry"
 		te.ExtendServer = &generator.APIExtension{
 			ImportPaths:  []string{"github.com/cloudwego/kitex/pkg/registry", "github.com/kitex-contrib/registry-polaris", "github.com/cloudwego/kitex/pkg/klog"},
-			ExtendOption: fmt.Sprintf(polarisServer, ca.Service),
+			ExtendOption: fmt.Sprintf(polarisServer, ca.ServerName),
 		}
 		te.ExtendClient = &generator.APIExtension{
 			ImportPaths:  []string{"github.com/cloudwego/kitex/pkg/registry", "github.com/kitex-contrib/registry-polaris", "github.com/cloudwego/kitex/pkg/klog"},
-			ExtendOption: fmt.Sprintf(polarisClient, ca.Service),
+			ExtendOption: fmt.Sprintf(polarisClient, ca.ServerName),
 		}
 	case consts.Nacos:
 		te.Dependencies["github.com/kitex-contrib/registry-nacos/registry"] = "registry"
 		te.Dependencies["github.com/kitex-contrib/registry-nacos/resolver"] = "resolver"
 		te.ExtendServer = &generator.APIExtension{
 			ImportPaths:  []string{"github.com/cloudwego/kitex/pkg/klog", "github.com/kitex-contrib/registry-nacos/registry", "github.com/cloudwego/kitex/pkg/rpcinfo"},
-			ExtendOption: fmt.Sprintf(nacosServer, ca.Service),
+			ExtendOption: fmt.Sprintf(nacosServer, ca.ServerName),
 		}
 		te.ExtendClient = &generator.APIExtension{
 			ImportPaths:  []string{"github.com/cloudwego/kitex/pkg/klog", "github.com/kitex-contrib/registry-nacos/resolver"},

--- a/pkg/consts/const.go
+++ b/pkg/consts/const.go
@@ -131,6 +131,7 @@ const (
 	DaoDir   = "dao_dir"
 
 	Service         = "service"
+	ServerName      = "server_name"
 	ServiceType     = "type"
 	Module          = "module"
 	IDLPath         = "idl"

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -41,8 +41,8 @@ func check(sa *config.ServerArgument) error {
 		return errors.New("unsupported registry")
 	}
 
-	if sa.Service == "" {
-		return errors.New("must specify service name")
+	if sa.Service == "" && sa.ServerName == "" {
+		return errors.New("must specify server name")
 	}
 
 	// handle cwd and output dir

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -41,7 +41,7 @@ func check(sa *config.ServerArgument) error {
 		return errors.New("unsupported registry")
 	}
 
-	if sa.Service == "" && sa.ServerName == "" {
+	if sa.ServerName == "" {
 		return errors.New("must specify server name")
 	}
 

--- a/pkg/server/hz.go
+++ b/pkg/server/hz.go
@@ -74,12 +74,7 @@ func convertHzArgument(sa *config.ServerArgument, hzArgument *hzConfig.Argument)
 
 	hzArgument.IdlPaths = []string{abPath}
 	hzArgument.Gomod = sa.GoMod
-	if sa.Service != "" {
-		hzArgument.ServiceName = sa.Service
-	}
-	if sa.ServerName != "" {
-		hzArgument.ServiceName = sa.ServerName
-	}
+	hzArgument.ServiceName = sa.ServerName
 	hzArgument.OutDir = sa.OutDir
 	hzArgument.Includes = sa.SliceParam.ProtoSearchPath
 	hzArgument.Cwd = sa.Cwd

--- a/pkg/server/hz.go
+++ b/pkg/server/hz.go
@@ -74,7 +74,12 @@ func convertHzArgument(sa *config.ServerArgument, hzArgument *hzConfig.Argument)
 
 	hzArgument.IdlPaths = []string{abPath}
 	hzArgument.Gomod = sa.GoMod
-	hzArgument.ServiceName = sa.Service
+	if sa.Service != "" {
+		hzArgument.ServiceName = sa.Service
+	}
+	if sa.ServerName != "" {
+		hzArgument.ServiceName = sa.ServerName
+	}
 	hzArgument.OutDir = sa.OutDir
 	hzArgument.Includes = sa.SliceParam.ProtoSearchPath
 	hzArgument.Cwd = sa.Cwd

--- a/pkg/server/kitex.go
+++ b/pkg/server/kitex.go
@@ -46,12 +46,7 @@ func convertKitexArgs(sa *config.ServerArgument, kitexArgument *kargs.Arguments)
 	f := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 	kitexArgument.ModuleName = sa.GoMod
-	if sa.Service != "" {
-		kitexArgument.ServiceName = sa.Service
-	}
-	if sa.ServerName != "" {
-		kitexArgument.ServiceName = sa.ServerName
-	}
+	kitexArgument.ServiceName = sa.ServerName
 	kitexArgument.Includes = sa.SliceParam.ProtoSearchPath
 	kitexArgument.Version = kitex.Version
 	kitexArgument.RecordCmd = os.Args

--- a/pkg/server/kitex.go
+++ b/pkg/server/kitex.go
@@ -46,7 +46,12 @@ func convertKitexArgs(sa *config.ServerArgument, kitexArgument *kargs.Arguments)
 	f := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 	kitexArgument.ModuleName = sa.GoMod
-	kitexArgument.ServiceName = sa.Service
+	if sa.Service != "" {
+		kitexArgument.ServiceName = sa.Service
+	}
+	if sa.ServerName != "" {
+		kitexArgument.ServiceName = sa.ServerName
+	}
 	kitexArgument.Includes = sa.SliceParam.ProtoSearchPath
 	kitexArgument.Version = kitex.Version
 	kitexArgument.RecordCmd = os.Args


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Change the parameter service to server_name.The service parameter name is not easily understood by the user.
zh: 修复service参数名称为server_name,service参数名称不容易被用户理解。

#### Which issue(s) this PR fixes:

