### PR TITLE
fix: Unused package import when response type and request type are in different packages

### DIFF
--- a/tpl/hertz/server/standard/package.yaml
+++ b/tpl/hertz/server/standard/package.yaml
@@ -33,13 +33,15 @@ layouts:
        }
        {{end}}
         {{if eq $MethodInfo.OutputDir "" -}}
-          resp,err := service.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
+          resp := &{{$MethodInfo.ReturnTypeName}}{}
+          resp,err = service.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
           if err != nil {
                utils.SendErrResponse(ctx, c, consts.StatusOK, err)
                return
           }
         {{else}}
-          resp,err := {{$MethodInfo.OutputDir}}.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
+          resp := &{{$MethodInfo.ReturnTypeName}}{}
+          resp,err = {{$MethodInfo.OutputDir}}.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
           if err != nil {
                   utils.SendErrResponse(ctx, c, consts.StatusOK, err)
                   return
@@ -133,7 +135,7 @@ layouts:
         w := ut.PerformRequest(h.Engine, "{{.HTTPMethod}}", path, body,header)
         resp := w.Result()
         t.Log(string(resp.Body()))
-        
+
         // todo edit your unit test.
         // assert.DeepEqual(t, 200, resp.StatusCode())
         // assert.DeepEqual(t, "null", string(resp.Body()))
@@ -158,7 +160,7 @@ layouts:
         w := ut.PerformRequest(h.Engine, "{{$MethodInfo.HTTPMethod}}", path, body,header)
         resp := w.Result()
         t.Log(string(resp.Body()))
-      
+
         // todo edit your unit test.
         // assert.DeepEqual(t, 200, resp.StatusCode())
         // assert.DeepEqual(t, "null", string(resp.Body()))

--- a/tpl/hertz/server/standard_v2/package.yaml
+++ b/tpl/hertz/server/standard_v2/package.yaml
@@ -34,13 +34,15 @@ layouts:
        }
        {{end}}
         {{if eq $MethodInfo.OutputDir "" -}}
-          resp,err := service.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
+          resp := &{{$MethodInfo.ReturnTypeName}}{}
+          resp,err = service.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
           if err != nil {
                utils.SendErrResponse(ctx, c, consts.StatusInternalServerError, err)
                return
           }
         {{else}}
-          resp,err := {{$MethodInfo.OutputDir}}.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
+          resp := &{{$MethodInfo.ReturnTypeName}}{}
+          resp,err = {{$MethodInfo.OutputDir}}.New{{$MethodInfo.Name}}Service(ctx, c).Run(&req)
           if err != nil {
                   utils.SendErrResponse(ctx, c, consts.StatusInternalServerError, err)
                   return
@@ -134,7 +136,7 @@ layouts:
         w := ut.PerformRequest(h.Engine, "{{.HTTPMethod}}", path, body,header)
         resp := w.Result()
         t.Log(string(resp.Body()))
-        
+
         // todo edit your unit test.
         // assert.DeepEqual(t, 200, resp.StatusCode())
         // assert.DeepEqual(t, "null", string(resp.Body()))
@@ -159,7 +161,7 @@ layouts:
         w := ut.PerformRequest(h.Engine, "{{$MethodInfo.HTTPMethod}}", path, body,header)
         resp := w.Result()
         t.Log(string(resp.Body()))
-      
+
         // todo edit your unit test.
         // assert.DeepEqual(t, 200, resp.StatusCode())
         // assert.DeepEqual(t, "null", string(resp.Body()))


### PR DESCRIPTION
…erent packages

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: 
zh: 当响应参数和请求参数包名不一样的时候，会多出来一个响应参数包的引用

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
