### PR TITLE
docs: fix zh docs

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -54,7 +54,7 @@ GOPROXY=https://goproxy.cn/,direct go install github.com/cloudwego/cwgo@latest
 
 ### 模板拓展
 
-包含用户自定义模板的使用，详见[文档](https://www.cloudwego.cn/zh/docs/cwgo/tutorials/templete-extension/)
+包含用户自定义模板的使用，详见[文档](https://www.cloudwego.io/zh/docs/cwgo/tutorials/templete-extension/)
 
 ### Layout
 
@@ -70,7 +70,7 @@ Layout 生成及 Layout 介绍，详见[文档](https://www.cloudwego.io/zh/docs
 
 ### Doc 
 
-包含如何使用 cwgo 工具生成文档型数据库 CURD 代码，详见[文档](https://www.cloudwego.cn/zh/docs/cwgo/tutorials/doc/)
+包含如何使用 cwgo 工具生成文档型数据库 CURD 代码，详见[文档](https://www.cloudwego.io/zh/docs/cwgo/tutorials/doc/)
 
 ### Api-list
 
@@ -78,11 +78,11 @@ Layout 生成及 Layout 介绍，详见[文档](https://www.cloudwego.io/zh/docs
 
 ### Server
 
-包含如何生成 RPC Server、HTTP Server 代码，详见[文档](https://www.cloudwego.cn/zh/docs/cwgo/tutorials/server/)
+包含如何生成 RPC Server、HTTP Server 代码，详见[文档](https://www.cloudwego.io/zh/docs/cwgo/tutorials/server/)
 
 ### 命令行自动补全
 
-包含如何启用命令行自动补全功能，详见[文档](https://www.cloudwego.cn/zh/docs/cwgo/tutorials/auto-completion/)
+包含如何启用命令行自动补全功能，详见[文档](https://www.cloudwego.io/zh/docs/cwgo/tutorials/auto-completion/)
 
 ## 开源许可
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
docs

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix the issue where some links in the Chinese documentation section of the README cannot be accessed.
zh: 修复readme中文文档部分链接无法访问问题

